### PR TITLE
All bot "attachment" messages in monospace

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -42,7 +42,6 @@ pre.special_formatting {
 }
 
 /* Bot messages: fixed font */
-ts-message.bot_message .message_body .msg_inline_attachment_column,
 ts-message[data-bot-id] .message_body .msg_inline_attachment_column {
   font-family: Consolas,monaco,"Ubuntu Mono",courier,monospace;
   font-size: 13px;
@@ -50,7 +49,6 @@ ts-message[data-bot-id] .message_body .msg_inline_attachment_column {
 }
 
 /* Bot messages: ovrride 600px width limitation ; highlight */
-ts-message.bot_message .message_body .attachment_group,
 ts-message[data-bot-id] .message_body .attachment_group {
   max-width: inherit;
   color: #333333;

--- a/custom.css
+++ b/custom.css
@@ -42,7 +42,8 @@ pre.special_formatting {
 }
 
 /* Bot messages: fixed font */
-ts-message.bot_message .message_body .msg_inline_attachment_column {
+ts-message.bot_message .message_body .msg_inline_attachment_column,
+ts-message[data-bot-id] .message_body .msg_inline_attachment_column {
   font-family: Consolas,monaco,"Ubuntu Mono",courier,monospace;
   font-size: 13px;
   line-height: 20px;


### PR DESCRIPTION
Sometimes bots do prose, but where attachments are involved, monospace makes sense. Experimenting.