### PR TITLE
Makefile: install via 'make install'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+UNAME := $(shell uname -s)
+GREP ?= grep -q
+SLACK_HACK ?= slack-hack.js
+
+ifeq ($(UNAME), Darwin)
+SSB_INTEROP = /Applications/Slack.app/Contents/Resources/app.asar.unpacked/src/static/ssb-interop.js
+else
+SSB_INTEROP = /usr/lib/slack/resources/app.asar.unpacked/src/static/ssb-interop.js
+endif
+
+.PHONY: install
+install:
+	@if ! $(GREP) "openark" $(SSB_INTEROP); then \
+		cat $(SLACK_HACK) >> $(SSB_INTEROP); \
+	fi

--- a/README.md
+++ b/README.md
@@ -42,17 +42,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
 If you cloned this repository locally, you may:
 
-```shell
-cat slack-hack.js >> /Applications/Slack.app/Contents/Resources/app.asar.unpacked/src/static/ssb-interop.js
+```ShellSession
+$ make
 ```
-
-on Mac OS/X, or:
-
-```shell
-cat slack-hack.js >> /usr/lib/slack/resources/app.asar.unpacked/src/static/ssb-interop.js
-```
-
-on Debian/Ubuntu.
 
 ### What happens on Slack upgrade?
 


### PR DESCRIPTION
Instead of including instructions in the README.md on how to install the
extension, let's ship a Makefile that can do it for us.

##

/cc @shlomi-noach 